### PR TITLE
Fix the compilation of the C# kata.

### DIFF
--- a/c#/TripServiceKata/TripServiceKata/Trip/TripService.cs
+++ b/c#/TripServiceKata/TripServiceKata/Trip/TripService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using TripServiceKata.Exception;
+using TripServiceKata.User;
 
 namespace TripServiceKata.Trip
 {
@@ -8,7 +9,7 @@ namespace TripServiceKata.Trip
         public List<Trip> GetTripsByUser(User.User user)
         {
             List<Trip> tripList = new List<Trip>();
-            User.User loggedUser = UserSession.GetInstance().getLoggedUser();
+            User.User loggedUser = UserSession.GetInstance().GetLoggedUser();
             bool isFriend = false;
             if (loggedUser != null)
             {

--- a/c#/TripServiceKata/TripServiceKata/User/UserSession.cs
+++ b/c#/TripServiceKata/TripServiceKata/User/UserSession.cs
@@ -19,7 +19,7 @@ namespace TripServiceKata.User
                 "UserSession.IsUserLoggedIn() should not be called in an unit test");
         }
 
-        public User GetLoggedUser(User user)
+        public User GetLoggedUser()
         {
             throw new DependendClassCallDuringUnitTestException(
                 "UserSession.GetLoggedUser() should not be called in an unit test");


### PR DESCRIPTION
This should fix the compilation of the C# kata to make it match the intent of the Java version.
