### PR TITLE
Swift 2.x porting of objc trip-service-kata project

### DIFF
--- a/Swift 2.x/TripServiceKata/TripServiceKata.xcodeproj/project.pbxproj
+++ b/Swift 2.x/TripServiceKata/TripServiceKata.xcodeproj/project.pbxproj
@@ -1,0 +1,450 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		1150099A1C7A816500945102 /* TripServiceKata.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 115009901C7A816500945102 /* TripServiceKata.framework */; };
+		11500B151C7A823C00945102 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11500B131C7A823C00945102 /* User.swift */; };
+		11500B161C7A823C00945102 /* UserSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11500B141C7A823C00945102 /* UserSession.swift */; };
+		11500B1A1C7A824500945102 /* Trip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11500B171C7A824500945102 /* Trip.swift */; };
+		11500B1B1C7A824500945102 /* TripDAO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11500B181C7A824500945102 /* TripDAO.swift */; };
+		11500B1C1C7A824500945102 /* TripService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11500B191C7A824500945102 /* TripService.swift */; };
+		11500B1E1C7A825000945102 /* TripServiceKataErrorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11500B1D1C7A825000945102 /* TripServiceKataErrorType.swift */; };
+		11500B241C7A84CD00945102 /* TripServiceKataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11500B231C7A84CD00945102 /* TripServiceKataTests.swift */; };
+		11500B251C7A864F00945102 /* TripServiceKata.h in Headers */ = {isa = PBXBuildFile; fileRef = 11500B211C7A83E100945102 /* TripServiceKata.h */; settings = {ATTRIBUTES = (Public, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		1150099B1C7A816500945102 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 115009511C7A773000945102 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1150098F1C7A816500945102;
+			remoteInfo = TripServiceKata;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		1150095C1C7A773000945102 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		115009681C7A773000945102 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		115009901C7A816500945102 /* TripServiceKata.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TripServiceKata.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		115009991C7A816500945102 /* TripServiceKataTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TripServiceKataTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		115009A01C7A816500945102 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		11500B131C7A823C00945102 /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
+		11500B141C7A823C00945102 /* UserSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserSession.swift; sourceTree = "<group>"; };
+		11500B171C7A824500945102 /* Trip.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Trip.swift; sourceTree = "<group>"; };
+		11500B181C7A824500945102 /* TripDAO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TripDAO.swift; sourceTree = "<group>"; };
+		11500B191C7A824500945102 /* TripService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TripService.swift; sourceTree = "<group>"; };
+		11500B1D1C7A825000945102 /* TripServiceKataErrorType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TripServiceKataErrorType.swift; sourceTree = "<group>"; };
+		11500B211C7A83E100945102 /* TripServiceKata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TripServiceKata.h; sourceTree = "<group>"; };
+		11500B231C7A84CD00945102 /* TripServiceKataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TripServiceKataTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		1150098C1C7A816500945102 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		115009961C7A816500945102 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1150099A1C7A816500945102 /* TripServiceKata.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		115009501C7A773000945102 = {
+			isa = PBXGroup;
+			children = (
+				1150095B1C7A773000945102 /* TripServiceKata */,
+				1150099D1C7A816500945102 /* TripServiceKataTests */,
+				1150095A1C7A773000945102 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		1150095A1C7A773000945102 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				115009901C7A816500945102 /* TripServiceKata.framework */,
+				115009991C7A816500945102 /* TripServiceKataTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		1150095B1C7A773000945102 /* TripServiceKata */ = {
+			isa = PBXGroup;
+			children = (
+				11500B211C7A83E100945102 /* TripServiceKata.h */,
+				1150095C1C7A773000945102 /* AppDelegate.swift */,
+				115009681C7A773000945102 /* Info.plist */,
+				1150097C1C7A7AD700945102 /* User */,
+				1150097F1C7A7B6D00945102 /* Trip */,
+				115009881C7A802400945102 /* ErrorType */,
+			);
+			path = TripServiceKata;
+			sourceTree = "<group>";
+		};
+		1150097C1C7A7AD700945102 /* User */ = {
+			isa = PBXGroup;
+			children = (
+				11500B131C7A823C00945102 /* User.swift */,
+				11500B141C7A823C00945102 /* UserSession.swift */,
+			);
+			name = User;
+			sourceTree = "<group>";
+		};
+		1150097F1C7A7B6D00945102 /* Trip */ = {
+			isa = PBXGroup;
+			children = (
+				11500B171C7A824500945102 /* Trip.swift */,
+				11500B181C7A824500945102 /* TripDAO.swift */,
+				11500B191C7A824500945102 /* TripService.swift */,
+			);
+			name = Trip;
+			sourceTree = "<group>";
+		};
+		115009881C7A802400945102 /* ErrorType */ = {
+			isa = PBXGroup;
+			children = (
+				11500B1D1C7A825000945102 /* TripServiceKataErrorType.swift */,
+			);
+			name = ErrorType;
+			sourceTree = "<group>";
+		};
+		1150099D1C7A816500945102 /* TripServiceKataTests */ = {
+			isa = PBXGroup;
+			children = (
+				11500B231C7A84CD00945102 /* TripServiceKataTests.swift */,
+				115009A01C7A816500945102 /* Info.plist */,
+			);
+			path = TripServiceKataTests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		1150098D1C7A816500945102 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				11500B251C7A864F00945102 /* TripServiceKata.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		1150098F1C7A816500945102 /* TripServiceKata */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 115009A11C7A816500945102 /* Build configuration list for PBXNativeTarget "TripServiceKata" */;
+			buildPhases = (
+				1150098B1C7A816500945102 /* Sources */,
+				1150098C1C7A816500945102 /* Frameworks */,
+				1150098D1C7A816500945102 /* Headers */,
+				1150098E1C7A816500945102 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TripServiceKata;
+			productName = TripServiceKata;
+			productReference = 115009901C7A816500945102 /* TripServiceKata.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		115009981C7A816500945102 /* TripServiceKataTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 115009A41C7A816500945102 /* Build configuration list for PBXNativeTarget "TripServiceKataTests" */;
+			buildPhases = (
+				115009951C7A816500945102 /* Sources */,
+				115009961C7A816500945102 /* Frameworks */,
+				115009971C7A816500945102 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1150099C1C7A816500945102 /* PBXTargetDependency */,
+			);
+			name = TripServiceKataTests;
+			productName = TripServiceKataTests;
+			productReference = 115009991C7A816500945102 /* TripServiceKataTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		115009511C7A773000945102 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0720;
+				LastUpgradeCheck = 0720;
+				ORGANIZATIONNAME = "Alessandro Benvenuti";
+				TargetAttributes = {
+					1150098F1C7A816500945102 = {
+						CreatedOnToolsVersion = 7.2.1;
+					};
+					115009981C7A816500945102 = {
+						CreatedOnToolsVersion = 7.2.1;
+					};
+				};
+			};
+			buildConfigurationList = 115009541C7A773000945102 /* Build configuration list for PBXProject "TripServiceKata" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 115009501C7A773000945102;
+			productRefGroup = 1150095A1C7A773000945102 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				1150098F1C7A816500945102 /* TripServiceKata */,
+				115009981C7A816500945102 /* TripServiceKataTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		1150098E1C7A816500945102 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		115009971C7A816500945102 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		1150098B1C7A816500945102 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				11500B1C1C7A824500945102 /* TripService.swift in Sources */,
+				11500B1B1C7A824500945102 /* TripDAO.swift in Sources */,
+				11500B151C7A823C00945102 /* User.swift in Sources */,
+				11500B1E1C7A825000945102 /* TripServiceKataErrorType.swift in Sources */,
+				11500B1A1C7A824500945102 /* Trip.swift in Sources */,
+				11500B161C7A823C00945102 /* UserSession.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		115009951C7A816500945102 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				11500B241C7A84CD00945102 /* TripServiceKataTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		1150099C1C7A816500945102 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1150098F1C7A816500945102 /* TripServiceKata */;
+			targetProxy = 1150099B1C7A816500945102 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		115009741C7A773000945102 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		115009751C7A773000945102 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		115009A21C7A816500945102 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = TripServiceKata/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Trinity-Mirror.TripServiceKata";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		115009A31C7A816500945102 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = TripServiceKata/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Trinity-Mirror.TripServiceKata";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		115009A51C7A816500945102 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				INFOPLIST_FILE = TripServiceKataTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Trinity-Mirror.TripServiceKataTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		115009A61C7A816500945102 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				INFOPLIST_FILE = TripServiceKataTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Trinity-Mirror.TripServiceKataTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		115009541C7A773000945102 /* Build configuration list for PBXProject "TripServiceKata" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				115009741C7A773000945102 /* Debug */,
+				115009751C7A773000945102 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		115009A11C7A816500945102 /* Build configuration list for PBXNativeTarget "TripServiceKata" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				115009A21C7A816500945102 /* Debug */,
+				115009A31C7A816500945102 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		115009A41C7A816500945102 /* Build configuration list for PBXNativeTarget "TripServiceKataTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				115009A51C7A816500945102 /* Debug */,
+				115009A61C7A816500945102 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 115009511C7A773000945102 /* Project object */;
+}

--- a/Swift 2.x/TripServiceKata/TripServiceKata.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Swift 2.x/TripServiceKata/TripServiceKata.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:TripServiceKata.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Swift 2.x/TripServiceKata/TripServiceKata/AppDelegate.swift
+++ b/Swift 2.x/TripServiceKata/TripServiceKata/AppDelegate.swift
@@ -1,0 +1,16 @@
+//
+//  AppDelegate.swift
+//  TripServiceKata
+//
+//  Created by Alessandro Benvenuti on 21/02/2016.
+//  Copyright © 2016 Alessandro Benvenuti. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate
+{
+    var window: UIWindow?
+}
+

--- a/Swift 2.x/TripServiceKata/TripServiceKata/Info.plist
+++ b/Swift 2.x/TripServiceKata/TripServiceKata/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Swift 2.x/TripServiceKata/TripServiceKata/Trip.swift
+++ b/Swift 2.x/TripServiceKata/TripServiceKata/Trip.swift
@@ -1,0 +1,11 @@
+//
+//  Trip.swift
+//  TripServiceKata
+//
+//  Created by Alessandro Benvenuti on 21/02/2016.
+//  Copyright © 2016 Alessandro Benvenuti. All rights reserved.
+//
+
+import Foundation
+
+class Trip { }

--- a/Swift 2.x/TripServiceKata/TripServiceKata/TripDAO.swift
+++ b/Swift 2.x/TripServiceKata/TripServiceKata/TripDAO.swift
@@ -1,0 +1,18 @@
+//
+//  TripDAO.swift
+//  TripServiceKata
+//
+//  Created by Alessandro Benvenuti on 21/02/2016.
+//  Copyright © 2016 Alessandro Benvenuti. All rights reserved.
+//
+
+import Foundation
+
+class TripDAO
+{
+    class func findTripsByUser(user:User) throws -> [Trip]?
+    {
+        throw UnitTestErrorType.DependendClassCallDuringUnitTest
+    }
+    
+}

--- a/Swift 2.x/TripServiceKata/TripServiceKata/TripService.swift
+++ b/Swift 2.x/TripServiceKata/TripServiceKata/TripService.swift
@@ -1,0 +1,36 @@
+//
+//  TripService.swift
+//  TripServiceKata
+//
+//  Created by Alessandro Benvenuti on 21/02/2016.
+//  Copyright © 2016 Alessandro Benvenuti. All rights reserved.
+//
+
+import Foundation
+
+class TripService
+{
+    func GetTripsByUser(user:User) throws -> [Trip]?
+    {
+        var tripList:[Trip]? = nil
+        let loggedUser = try! UserSession.sharedInstance.getLoggedUser()
+        
+        var isFriend = false
+        
+        if let loggedUser = loggedUser {
+            for friend in user.getFriends() {
+                if friend == loggedUser {
+                    isFriend = true
+                    break
+                }
+            }
+            if isFriend {
+                tripList = try! TripDAO.findTripsByUser(user)
+            }
+            return tripList
+        }
+        else {
+            throw TripServiceErrorType.UserNotLoggedIn
+        }
+    }
+}

--- a/Swift 2.x/TripServiceKata/TripServiceKata/TripServiceKata.h
+++ b/Swift 2.x/TripServiceKata/TripServiceKata/TripServiceKata.h
@@ -1,0 +1,19 @@
+//
+//  TripServiceKataFW.h
+//  TripServiceKataFW
+//
+//  Created by Alessandro Benvenuti on 21/02/2016.
+//  Copyright © 2016 Alessandro Benvenuti. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for TripServiceKataFW.
+FOUNDATION_EXPORT double TripServiceKataFWVersionNumber;
+
+//! Project version string for TripServiceKataFW.
+FOUNDATION_EXPORT const unsigned char TripServiceKataFWVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <TripServiceKataFW/PublicHeader.h>
+
+

--- a/Swift 2.x/TripServiceKata/TripServiceKata/TripServiceKataErrorType.swift
+++ b/Swift 2.x/TripServiceKata/TripServiceKata/TripServiceKataErrorType.swift
@@ -1,0 +1,19 @@
+//
+//  UnitTestErrorType.swift
+//  TripServiceKata
+//
+//  Created by Alessandro Benvenuti on 21/02/2016.
+//  Copyright © 2016 Alessandro Benvenuti. All rights reserved.
+//
+
+import Foundation
+
+enum UnitTestErrorType : ErrorType
+{
+    case DependendClassCallDuringUnitTest
+}
+
+enum TripServiceErrorType : ErrorType
+{
+    case UserNotLoggedIn
+}

--- a/Swift 2.x/TripServiceKata/TripServiceKata/User.swift
+++ b/Swift 2.x/TripServiceKata/TripServiceKata/User.swift
@@ -1,0 +1,40 @@
+//
+//  User.swift
+//  TripServiceKata
+//
+//  Created by Alessandro Benvenuti on 21/02/2016.
+//  Copyright © 2016 Alessandro Benvenuti. All rights reserved.
+//
+
+import Foundation
+
+func ==(lhs: User, rhs: User) -> Bool
+{
+    return lhs === rhs
+}
+
+class User : Equatable
+{
+    private var userTrips:[Trip] = []
+    private var friends:[User] = []
+    
+    func getFriends() -> [User]
+    {
+        return self.friends
+    }
+    
+    func addFriend(friend:User)
+    {
+        self.friends.append(friend)
+    }
+    
+    func trips() -> [Trip]
+    {
+        return self.userTrips
+    }
+    
+    func addTrip(trip:Trip)
+    {
+        self.userTrips.append(trip)
+    }
+}

--- a/Swift 2.x/TripServiceKata/TripServiceKata/UserSession.swift
+++ b/Swift 2.x/TripServiceKata/TripServiceKata/UserSession.swift
@@ -1,0 +1,24 @@
+//
+//  UserSession.swift
+//  TripServiceKata
+//
+//  Created by Alessandro Benvenuti on 21/02/2016.
+//  Copyright © 2016 Alessandro Benvenuti. All rights reserved.
+//
+
+import Foundation
+
+class UserSession
+{
+    static var sharedInstance:UserSession = UserSession()
+    
+    func isUserLoggedIn(user:User) throws -> Bool
+    {
+        throw UnitTestErrorType.DependendClassCallDuringUnitTest
+    }
+    
+    func getLoggedUser() throws -> User?
+    {
+        throw UnitTestErrorType.DependendClassCallDuringUnitTest
+    }
+}

--- a/Swift 2.x/TripServiceKata/TripServiceKataTests/Info.plist
+++ b/Swift 2.x/TripServiceKata/TripServiceKataTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Swift 2.x/TripServiceKata/TripServiceKataTests/TripServiceKataTests.swift
+++ b/Swift 2.x/TripServiceKata/TripServiceKataTests/TripServiceKataTests.swift
@@ -1,0 +1,36 @@
+//
+//  TripServiceKataTests.swift
+//  TripServiceKataTests
+//
+//  Created by Alessandro Benvenuti on 21/02/2016.
+//  Copyright © 2016 Alessandro Benvenuti. All rights reserved.
+//
+
+import XCTest
+@testable import TripServiceKata
+
+class TripServiceKataTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measureBlock {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+}


### PR DESCRIPTION
Hi Sandro,

it's Alessandro, we met at the TDD Training in Trinity Mirror, this is my private github account.
As agreed I've created the Swift 2.x version of the project! :-)
It compiles and the code should be aligned with what already is in the objc version.
Of course there are differences such as no exceptions, methods **throw** instead, and a few methods return optional values. 
For know all the files have an header with my name, let me know how do you want me to change it.