### PR TITLE
Add coverage for js

### DIFF
--- a/javascript/.gitignore
+++ b/javascript/.gitignore
@@ -1,0 +1,1 @@
+/coverage/

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -1,5 +1,7 @@
 A JavaScript (ES6 / ES2015) port of the Trip Service Kata.
 
-* Requirements: Recent version of node.js (tested on 5.1.0).
+* Requirements: Recent version of node.js (tested on 5.1.0). 
 * Install Dependencies: `npm install`
 * Run tests with file watching for fast feedback: `npm test -- --watch`
+* Coverage `npm run coverage`
+    *  Then open `coverage/lcov-report/index.html` 

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "Kata for a legacy code hands-on session. The objective is to write tests and refactor the given legacy code.",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "coverage": "istanbul cover _mocha"
   },
   "repository": {
     "type": "git",
@@ -18,8 +19,7 @@
   },
   "homepage": "https://github.com/sandromancuso/trip-service-kata",
   "devDependencies": {
-    "babel-core": "^6.2.1",
-    "babel-preset-es2015": "^6.1.18",
+    "istanbul": "^0.4.5",
     "mocha": "^2.3.4",
     "sinon": "^1.17.2"
   }

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Kata for a legacy code hands-on session. The objective is to write tests and refactor the given legacy code.",
   "scripts": {
-    "test": "mocha --compilers js:babel-core/register"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",

--- a/javascript/src/TripDAO.js
+++ b/javascript/src/TripDAO.js
@@ -1,3 +1,7 @@
-export default function findTripsByUser(user) {
+"use strict";
+
+function findTripsByUser(user) {
     throw new Error("TripDAO should not be invoked on an unit test.");
 }
+
+module.exports = {findTripsByUser}

--- a/javascript/src/TripService.js
+++ b/javascript/src/TripService.js
@@ -1,7 +1,9 @@
-import UserSession from './UserSession';
-import TripDAO from './TripDAO';
+"use strict";
 
-export default class TripService {
+let UserSession = require('./UserSession');
+let TripDAO = require('./TripDAO');
+
+class TripService {
     getTripsByUser(user) {
         let tripList = [];
         let loggedUser = UserSession.getLoggedUser();
@@ -24,3 +26,5 @@ export default class TripService {
         }
     }
 }
+
+module.exports = TripService

--- a/javascript/src/User.js
+++ b/javascript/src/User.js
@@ -1,0 +1,3 @@
+export default class User {
+
+}

--- a/javascript/src/User.js
+++ b/javascript/src/User.js
@@ -1,3 +1,5 @@
-export default class User {
+"use strict";
+
+module.exports = class User {
 
 }

--- a/javascript/src/UserSession.js
+++ b/javascript/src/UserSession.js
@@ -1,3 +1,5 @@
+"use strict";
+
 class UserSession {
     getLoggedUser() {
         throw new Error("UserSession.getLoggedUser() should not be called in an unit test");
@@ -5,4 +7,4 @@ class UserSession {
 
 }
 
-export default new UserSession();
+module.exports = new UserSession();

--- a/javascript/test/TripServiceSpec.js
+++ b/javascript/test/TripServiceSpec.js
@@ -1,5 +1,7 @@
-import assert from 'assert';
-import TripService from '../src/TripService';
+"use strict";
+
+let assert = require('assert');
+let TripService = require('../src/TripService');
 
 describe('TripService', () => {
 


### PR DESCRIPTION
Seems to me that we lacked a convenient way of having code coverage for the javascript version.

In order to add coverage easily, I removed the new es6 module syntax in favor of current nodejs syntax (keeping all the other es6 though). In theory it can be done with nyc, babel, babel-plugin-istanbul. However I had difficulties making it work. It also pulls heavy dependencies. To me the module syntax is not important for the purpose of this kata and making setup fast and foolproof has value.

I might be missing some easy way of doing it though. WDYT @c089 