### PR TITLE
Fix UserSession.get_instance to be a class method

### DIFF
--- a/ruby/user/user_session.rb
+++ b/ruby/user/user_session.rb
@@ -3,7 +3,7 @@ require_relative '../еxceptions/dependend_class_call_during_unit_test_exception
 class UserSession
     @@user_session = UserSession.new
 
-    def get_instance
+    def self.get_instance
         @@user_session
     end
 


### PR DESCRIPTION
In the ruby implementation the UserSession.get_instance wasn't defined
as class method and the following line (in trip/trip_service.rb:11)
will blow up if stimulated:

        logged_user = UserSession.get_instance.get_logged_user

The solution is to defining get_instance as class method in
user_session.rb, instead of using:

    def self.get_instance
        ...
    end 

now we use

    def get_instance
        ...
    end