### PR TITLE
Swift 4

### DIFF
--- a/Swift 4.x/TripServiceKata/.gitignore
+++ b/Swift 4.x/TripServiceKata/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/Swift 4.x/TripServiceKata/.gitignore
+++ b/Swift 4.x/TripServiceKata/.gitignore
@@ -1,4 +1,3 @@
 .DS_Store
 /.build
 /Packages
-/*.xcodeproj

--- a/Swift 4.x/TripServiceKata/Package.swift
+++ b/Swift 4.x/TripServiceKata/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "TripServiceKata",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "TripServiceKata",
+            targets: ["TripServiceKata"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "TripServiceKata",
+            dependencies: []),
+        .testTarget(
+            name: "TripServiceKataTests",
+            dependencies: ["TripServiceKata"]),
+    ]
+)

--- a/Swift 4.x/TripServiceKata/README.md
+++ b/Swift 4.x/TripServiceKata/README.md
@@ -1,0 +1,3 @@
+# TripServiceKata
+
+A description of this package.

--- a/Swift 4.x/TripServiceKata/README.md
+++ b/Swift 4.x/TripServiceKata/README.md
@@ -1,3 +1,17 @@
 # TripServiceKata
 
-A description of this package.
+A Swift 4 port of the Trip Service Kata.
+
+## Requirements
+- Swift 4
+- Xcode 9.1 (if you want to work with Xcode)
+
+## Swift Package
+Since this is a Swift Package, you don't need Xcode to build the project or run the test.  
+You can build the package on the command line with `swift build`.  
+You can build the package and run the tests with `swift test`.
+
+The Xcode project file is just included for convenience.  
+It can be recreated at any time with `swift package generate-xcodeproj`.
+
+Happy Coding 🐳

--- a/Swift 4.x/TripServiceKata/Sources/TripServiceKata/Trip.swift
+++ b/Swift 4.x/TripServiceKata/Sources/TripServiceKata/Trip.swift
@@ -1,0 +1,11 @@
+//
+//  Trip.swift
+//  TripServiceKata
+//
+//  Created by Alessandro Benvenuti on 21/02/2016.
+//  Copyright © 2016 Alessandro Benvenuti. All rights reserved.
+//
+
+import Foundation
+
+class Trip { }

--- a/Swift 4.x/TripServiceKata/Sources/TripServiceKata/Trip.swift
+++ b/Swift 4.x/TripServiceKata/Sources/TripServiceKata/Trip.swift
@@ -1,11 +1,3 @@
-//
-//  Trip.swift
-//  TripServiceKata
-//
-//  Created by Alessandro Benvenuti on 21/02/2016.
-//  Copyright © 2016 Alessandro Benvenuti. All rights reserved.
-//
-
 import Foundation
 
 class Trip { }

--- a/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripDAO.swift
+++ b/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripDAO.swift
@@ -1,0 +1,18 @@
+//
+//  TripDAO.swift
+//  TripServiceKata
+//
+//  Created by Alessandro Benvenuti on 21/02/2016.
+//  Copyright © 2016 Alessandro Benvenuti. All rights reserved.
+//
+
+import Foundation
+
+class TripDAO
+{
+    class func findTripsByUser(user:User) throws -> [Trip]?
+    {
+        throw UnitTestErrorType.DependendClassCallDuringUnitTest
+    }
+    
+}

--- a/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripDAO.swift
+++ b/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripDAO.swift
@@ -10,9 +10,9 @@ import Foundation
 
 class TripDAO
 {
-    class func findTripsByUser(user:User) throws -> [Trip]?
+    class func findTripsByUser(_ user:User) throws -> [Trip]?
     {
-        throw UnitTestErrorType.DependendClassCallDuringUnitTest
+        throw UnitTestErrorType.dependendClassCallDuringUnitTest
     }
     
 }

--- a/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripDAO.swift
+++ b/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripDAO.swift
@@ -1,11 +1,3 @@
-//
-//  TripDAO.swift
-//  TripServiceKata
-//
-//  Created by Alessandro Benvenuti on 21/02/2016.
-//  Copyright © 2016 Alessandro Benvenuti. All rights reserved.
-//
-
 import Foundation
 
 class TripDAO

--- a/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripService.swift
+++ b/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripService.swift
@@ -1,0 +1,36 @@
+//
+//  TripService.swift
+//  TripServiceKata
+//
+//  Created by Alessandro Benvenuti on 21/02/2016.
+//  Copyright © 2016 Alessandro Benvenuti. All rights reserved.
+//
+
+import Foundation
+
+class TripService
+{
+    func GetTripsByUser(user:User) throws -> [Trip]?
+    {
+        var tripList:[Trip]? = nil
+        let loggedUser = try! UserSession.sharedInstance.getLoggedUser()
+        
+        var isFriend = false
+        
+        if let loggedUser = loggedUser {
+            for friend in user.getFriends() {
+                if friend == loggedUser {
+                    isFriend = true
+                    break
+                }
+            }
+            if isFriend {
+                tripList = try! TripDAO.findTripsByUser(user)
+            }
+            return tripList
+        }
+        else {
+            throw TripServiceErrorType.UserNotLoggedIn
+        }
+    }
+}

--- a/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripService.swift
+++ b/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripService.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class TripService
 {
-    func GetTripsByUser(_ user:User) throws -> [Trip]?
+    func getTripsByUser(_ user:User) throws -> [Trip]?
     {
         var tripList:[Trip]? = nil
         let loggedUser = try! UserSession.sharedInstance.getLoggedUser()

--- a/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripService.swift
+++ b/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripService.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class TripService
 {
-    func GetTripsByUser(user:User) throws -> [Trip]?
+    func GetTripsByUser(_ user:User) throws -> [Trip]?
     {
         var tripList:[Trip]? = nil
         let loggedUser = try! UserSession.sharedInstance.getLoggedUser()
@@ -30,7 +30,7 @@ class TripService
             return tripList
         }
         else {
-            throw TripServiceErrorType.UserNotLoggedIn
+            throw TripServiceErrorType.userNotLoggedIn
         }
     }
 }

--- a/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripService.swift
+++ b/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripService.swift
@@ -1,11 +1,3 @@
-//
-//  TripService.swift
-//  TripServiceKata
-//
-//  Created by Alessandro Benvenuti on 21/02/2016.
-//  Copyright © 2016 Alessandro Benvenuti. All rights reserved.
-//
-
 import Foundation
 
 class TripService

--- a/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripServiceKata.swift
+++ b/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripServiceKata.swift
@@ -1,0 +1,3 @@
+struct TripServiceKata {
+    var text = "Hello, World!"
+}

--- a/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripServiceKata.swift
+++ b/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripServiceKata.swift
@@ -1,3 +1,0 @@
-struct TripServiceKata {
-    var text = "Hello, World!"
-}

--- a/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripServiceKataErrorType.swift
+++ b/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripServiceKataErrorType.swift
@@ -1,0 +1,19 @@
+//
+//  UnitTestErrorType.swift
+//  TripServiceKata
+//
+//  Created by Alessandro Benvenuti on 21/02/2016.
+//  Copyright © 2016 Alessandro Benvenuti. All rights reserved.
+//
+
+import Foundation
+
+enum UnitTestErrorType : ErrorType
+{
+    case DependendClassCallDuringUnitTest
+}
+
+enum TripServiceErrorType : ErrorType
+{
+    case UserNotLoggedIn
+}

--- a/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripServiceKataErrorType.swift
+++ b/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripServiceKataErrorType.swift
@@ -1,11 +1,3 @@
-//
-//  UnitTestErrorType.swift
-//  TripServiceKata
-//
-//  Created by Alessandro Benvenuti on 21/02/2016.
-//  Copyright © 2016 Alessandro Benvenuti. All rights reserved.
-//
-
 import Foundation
 
 enum UnitTestErrorType : Error

--- a/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripServiceKataErrorType.swift
+++ b/Swift 4.x/TripServiceKata/Sources/TripServiceKata/TripServiceKataErrorType.swift
@@ -8,12 +8,12 @@
 
 import Foundation
 
-enum UnitTestErrorType : ErrorType
+enum UnitTestErrorType : Error
 {
-    case DependendClassCallDuringUnitTest
+    case dependendClassCallDuringUnitTest
 }
 
-enum TripServiceErrorType : ErrorType
+enum TripServiceErrorType : Error
 {
-    case UserNotLoggedIn
+    case userNotLoggedIn
 }

--- a/Swift 4.x/TripServiceKata/Sources/TripServiceKata/User.swift
+++ b/Swift 4.x/TripServiceKata/Sources/TripServiceKata/User.swift
@@ -1,0 +1,40 @@
+//
+//  User.swift
+//  TripServiceKata
+//
+//  Created by Alessandro Benvenuti on 21/02/2016.
+//  Copyright © 2016 Alessandro Benvenuti. All rights reserved.
+//
+
+import Foundation
+
+func ==(lhs: User, rhs: User) -> Bool
+{
+    return lhs === rhs
+}
+
+class User : Equatable
+{
+    private var userTrips:[Trip] = []
+    private var friends:[User] = []
+    
+    func getFriends() -> [User]
+    {
+        return self.friends
+    }
+    
+    func addFriend(friend:User)
+    {
+        self.friends.append(friend)
+    }
+    
+    func trips() -> [Trip]
+    {
+        return self.userTrips
+    }
+    
+    func addTrip(trip:Trip)
+    {
+        self.userTrips.append(trip)
+    }
+}

--- a/Swift 4.x/TripServiceKata/Sources/TripServiceKata/User.swift
+++ b/Swift 4.x/TripServiceKata/Sources/TripServiceKata/User.swift
@@ -1,11 +1,3 @@
-//
-//  User.swift
-//  TripServiceKata
-//
-//  Created by Alessandro Benvenuti on 21/02/2016.
-//  Copyright © 2016 Alessandro Benvenuti. All rights reserved.
-//
-
 import Foundation
 
 func ==(lhs: User, rhs: User) -> Bool

--- a/Swift 4.x/TripServiceKata/Sources/TripServiceKata/User.swift
+++ b/Swift 4.x/TripServiceKata/Sources/TripServiceKata/User.swift
@@ -15,15 +15,15 @@ func ==(lhs: User, rhs: User) -> Bool
 
 class User : Equatable
 {
-    private var userTrips:[Trip] = []
-    private var friends:[User] = []
+    fileprivate var userTrips:[Trip] = []
+    fileprivate var friends:[User] = []
     
     func getFriends() -> [User]
     {
         return self.friends
     }
     
-    func addFriend(friend:User)
+    func addFriend(_ friend:User)
     {
         self.friends.append(friend)
     }
@@ -33,7 +33,7 @@ class User : Equatable
         return self.userTrips
     }
     
-    func addTrip(trip:Trip)
+    func addTrip(_ trip:Trip)
     {
         self.userTrips.append(trip)
     }

--- a/Swift 4.x/TripServiceKata/Sources/TripServiceKata/User.swift
+++ b/Swift 4.x/TripServiceKata/Sources/TripServiceKata/User.swift
@@ -15,8 +15,8 @@ func ==(lhs: User, rhs: User) -> Bool
 
 class User : Equatable
 {
-    fileprivate var userTrips:[Trip] = []
-    fileprivate var friends:[User] = []
+    private var userTrips:[Trip] = []
+    private var friends:[User] = []
     
     func getFriends() -> [User]
     {

--- a/Swift 4.x/TripServiceKata/Sources/TripServiceKata/UserSession.swift
+++ b/Swift 4.x/TripServiceKata/Sources/TripServiceKata/UserSession.swift
@@ -1,0 +1,24 @@
+//
+//  UserSession.swift
+//  TripServiceKata
+//
+//  Created by Alessandro Benvenuti on 21/02/2016.
+//  Copyright © 2016 Alessandro Benvenuti. All rights reserved.
+//
+
+import Foundation
+
+class UserSession
+{
+    static var sharedInstance:UserSession = UserSession()
+    
+    func isUserLoggedIn(user:User) throws -> Bool
+    {
+        throw UnitTestErrorType.DependendClassCallDuringUnitTest
+    }
+    
+    func getLoggedUser() throws -> User?
+    {
+        throw UnitTestErrorType.DependendClassCallDuringUnitTest
+    }
+}

--- a/Swift 4.x/TripServiceKata/Sources/TripServiceKata/UserSession.swift
+++ b/Swift 4.x/TripServiceKata/Sources/TripServiceKata/UserSession.swift
@@ -12,13 +12,13 @@ class UserSession
 {
     static var sharedInstance:UserSession = UserSession()
     
-    func isUserLoggedIn(user:User) throws -> Bool
+    func isUserLoggedIn(_ user:User) throws -> Bool
     {
-        throw UnitTestErrorType.DependendClassCallDuringUnitTest
+        throw UnitTestErrorType.dependendClassCallDuringUnitTest
     }
     
     func getLoggedUser() throws -> User?
     {
-        throw UnitTestErrorType.DependendClassCallDuringUnitTest
+        throw UnitTestErrorType.dependendClassCallDuringUnitTest
     }
 }

--- a/Swift 4.x/TripServiceKata/Sources/TripServiceKata/UserSession.swift
+++ b/Swift 4.x/TripServiceKata/Sources/TripServiceKata/UserSession.swift
@@ -1,11 +1,3 @@
-//
-//  UserSession.swift
-//  TripServiceKata
-//
-//  Created by Alessandro Benvenuti on 21/02/2016.
-//  Copyright © 2016 Alessandro Benvenuti. All rights reserved.
-//
-
 import Foundation
 
 class UserSession

--- a/Swift 4.x/TripServiceKata/Tests/LinuxMain.swift
+++ b/Swift 4.x/TripServiceKata/Tests/LinuxMain.swift
@@ -1,0 +1,6 @@
+import XCTest
+@testable import TripServiceKataTests
+
+XCTMain([
+    testCase(TripServiceKataTests.allTests),
+])

--- a/Swift 4.x/TripServiceKata/Tests/TripServiceKataTests/TripServiceKataTests.swift
+++ b/Swift 4.x/TripServiceKata/Tests/TripServiceKataTests/TripServiceKataTests.swift
@@ -4,13 +4,7 @@ import XCTest
 class TripServiceKataTests: XCTestCase {
     func testExample() {
         // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
-        XCTAssertEqual(TripServiceKata().text, "Hello, World!")
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        XCTAssertTrue(true)
     }
-
-
-    static var allTests = [
-        ("testExample", testExample),
-    ]
 }

--- a/Swift 4.x/TripServiceKata/Tests/TripServiceKataTests/TripServiceKataTests.swift
+++ b/Swift 4.x/TripServiceKata/Tests/TripServiceKataTests/TripServiceKataTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import TripServiceKata
+
+class TripServiceKataTests: XCTestCase {
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+        XCTAssertEqual(TripServiceKata().text, "Hello, World!")
+    }
+
+
+    static var allTests = [
+        ("testExample", testExample),
+    ]
+}

--- a/Swift 4.x/TripServiceKata/TripServiceKata.xcodeproj/TripServiceKataTests_Info.plist
+++ b/Swift 4.x/TripServiceKata/TripServiceKata.xcodeproj/TripServiceKataTests_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>BNDL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/Swift 4.x/TripServiceKata/TripServiceKata.xcodeproj/TripServiceKata_Info.plist
+++ b/Swift 4.x/TripServiceKata/TripServiceKata.xcodeproj/TripServiceKata_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/Swift 4.x/TripServiceKata/TripServiceKata.xcodeproj/project.pbxproj
+++ b/Swift 4.x/TripServiceKata/TripServiceKata.xcodeproj/project.pbxproj
@@ -1,0 +1,470 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		"TripServiceKata::TripServiceKataPackageTests::ProductTarget" /* TripServiceKataPackageTests */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = OBJ_49 /* Build configuration list for PBXAggregateTarget "TripServiceKataPackageTests" */;
+			buildPhases = (
+			);
+			dependencies = (
+				OBJ_52 /* PBXTargetDependency */,
+			);
+			name = TripServiceKataPackageTests;
+			productName = TripServiceKataPackageTests;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		OBJ_26 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
+		OBJ_32 /* TripServiceKataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* TripServiceKataTests.swift */; };
+		OBJ_34 /* TripServiceKata.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "TripServiceKata::TripServiceKata::Product" /* TripServiceKata.framework */; };
+		OBJ_41 /* Trip.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* Trip.swift */; };
+		OBJ_42 /* TripDAO.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* TripDAO.swift */; };
+		OBJ_43 /* TripService.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* TripService.swift */; };
+		OBJ_44 /* TripServiceKataErrorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* TripServiceKataErrorType.swift */; };
+		OBJ_45 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* User.swift */; };
+		OBJ_46 /* UserSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* UserSession.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		179BF9721FD40C32000329DD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "TripServiceKata::TripServiceKata";
+			remoteInfo = TripServiceKata;
+		};
+		179BF9731FD40C33000329DD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "TripServiceKata::TripServiceKataTests";
+			remoteInfo = TripServiceKataTests;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		OBJ_10 /* TripDAO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripDAO.swift; sourceTree = "<group>"; };
+		OBJ_11 /* TripService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripService.swift; sourceTree = "<group>"; };
+		OBJ_12 /* TripServiceKataErrorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripServiceKataErrorType.swift; sourceTree = "<group>"; };
+		OBJ_13 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
+		OBJ_14 /* UserSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSession.swift; sourceTree = "<group>"; };
+		OBJ_17 /* TripServiceKataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripServiceKataTests.swift; sourceTree = "<group>"; };
+		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		OBJ_9 /* Trip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trip.swift; sourceTree = "<group>"; };
+		"TripServiceKata::TripServiceKata::Product" /* TripServiceKata.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = TripServiceKata.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"TripServiceKata::TripServiceKataTests::Product" /* TripServiceKataTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = TripServiceKataTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		OBJ_33 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_34 /* TripServiceKata.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_47 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		OBJ_15 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_16 /* TripServiceKataTests */,
+			);
+			name = Tests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_16 /* TripServiceKataTests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_17 /* TripServiceKataTests.swift */,
+			);
+			name = TripServiceKataTests;
+			path = Tests/TripServiceKataTests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_18 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				"TripServiceKata::TripServiceKataTests::Product" /* TripServiceKataTests.xctest */,
+				"TripServiceKata::TripServiceKata::Product" /* TripServiceKata.framework */,
+			);
+			name = Products;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		OBJ_5 /*  */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_6 /* Package.swift */,
+				OBJ_7 /* Sources */,
+				OBJ_15 /* Tests */,
+				OBJ_18 /* Products */,
+			);
+			name = "";
+			sourceTree = "<group>";
+		};
+		OBJ_7 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_8 /* TripServiceKata */,
+			);
+			name = Sources;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_8 /* TripServiceKata */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_9 /* Trip.swift */,
+				OBJ_10 /* TripDAO.swift */,
+				OBJ_11 /* TripService.swift */,
+				OBJ_12 /* TripServiceKataErrorType.swift */,
+				OBJ_13 /* User.swift */,
+				OBJ_14 /* UserSession.swift */,
+			);
+			name = TripServiceKata;
+			path = Sources/TripServiceKata;
+			sourceTree = SOURCE_ROOT;
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		"TripServiceKata::SwiftPMPackageDescription" /* TripServiceKataPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_22 /* Build configuration list for PBXNativeTarget "TripServiceKataPackageDescription" */;
+			buildPhases = (
+				OBJ_25 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TripServiceKataPackageDescription;
+			productName = TripServiceKataPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"TripServiceKata::TripServiceKata" /* TripServiceKata */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_37 /* Build configuration list for PBXNativeTarget "TripServiceKata" */;
+			buildPhases = (
+				OBJ_40 /* Sources */,
+				OBJ_47 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TripServiceKata;
+			productName = TripServiceKata;
+			productReference = "TripServiceKata::TripServiceKata::Product" /* TripServiceKata.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"TripServiceKata::TripServiceKataTests" /* TripServiceKataTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_28 /* Build configuration list for PBXNativeTarget "TripServiceKataTests" */;
+			buildPhases = (
+				OBJ_31 /* Sources */,
+				OBJ_33 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_35 /* PBXTargetDependency */,
+			);
+			name = TripServiceKataTests;
+			productName = TripServiceKataTests;
+			productReference = "TripServiceKata::TripServiceKataTests::Product" /* TripServiceKataTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		OBJ_1 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 9999;
+			};
+			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "TripServiceKata" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = OBJ_5 /*  */;
+			productRefGroup = OBJ_18 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				"TripServiceKata::SwiftPMPackageDescription" /* TripServiceKataPackageDescription */,
+				"TripServiceKata::TripServiceKataTests" /* TripServiceKataTests */,
+				"TripServiceKata::TripServiceKata" /* TripServiceKata */,
+				"TripServiceKata::TripServiceKataPackageTests::ProductTarget" /* TripServiceKataPackageTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		OBJ_25 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_26 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_31 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_32 /* TripServiceKataTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_40 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_41 /* Trip.swift in Sources */,
+				OBJ_42 /* TripDAO.swift in Sources */,
+				OBJ_43 /* TripService.swift in Sources */,
+				OBJ_44 /* TripServiceKataErrorType.swift in Sources */,
+				OBJ_45 /* User.swift in Sources */,
+				OBJ_46 /* UserSession.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		OBJ_35 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "TripServiceKata::TripServiceKata" /* TripServiceKata */;
+			targetProxy = 179BF9721FD40C32000329DD /* PBXContainerItemProxy */;
+		};
+		OBJ_52 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "TripServiceKata::TripServiceKataTests" /* TripServiceKataTests */;
+			targetProxy = 179BF9731FD40C33000329DD /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		OBJ_23 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		OBJ_24 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
+		OBJ_29 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = TripServiceKata.xcodeproj/TripServiceKataTests_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = TripServiceKataTests;
+			};
+			name = Debug;
+		};
+		OBJ_3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		OBJ_30 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = TripServiceKata.xcodeproj/TripServiceKataTests_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @loader_path/Frameworks";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = TripServiceKataTests;
+			};
+			name = Release;
+		};
+		OBJ_38 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = TripServiceKata.xcodeproj/TripServiceKata_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = TripServiceKata;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = TripServiceKata;
+			};
+			name = Debug;
+		};
+		OBJ_39 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = TripServiceKata.xcodeproj/TripServiceKata_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = TripServiceKata;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = TripServiceKata;
+			};
+			name = Release;
+		};
+		OBJ_4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_OPTIMIZATION_LEVEL = s;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		OBJ_50 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		OBJ_51 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		OBJ_2 /* Build configuration list for PBXProject "TripServiceKata" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_3 /* Debug */,
+				OBJ_4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		OBJ_22 /* Build configuration list for PBXNativeTarget "TripServiceKataPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_23 /* Debug */,
+				OBJ_24 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		OBJ_28 /* Build configuration list for PBXNativeTarget "TripServiceKataTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_29 /* Debug */,
+				OBJ_30 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		OBJ_37 /* Build configuration list for PBXNativeTarget "TripServiceKata" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_38 /* Debug */,
+				OBJ_39 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		OBJ_49 /* Build configuration list for PBXAggregateTarget "TripServiceKataPackageTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_50 /* Debug */,
+				OBJ_51 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = OBJ_1 /* Project object */;
+}

--- a/Swift 4.x/TripServiceKata/TripServiceKata.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Swift 4.x/TripServiceKata/TripServiceKata.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Swift 4.x/TripServiceKata/TripServiceKata.xcodeproj/xcshareddata/xcschemes/TripServiceKata-Package.xcscheme
+++ b/Swift 4.x/TripServiceKata/TripServiceKata.xcodeproj/xcshareddata/xcschemes/TripServiceKata-Package.xcscheme
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "TripServiceKata::TripServiceKata"
+               BuildableName = "TripServiceKata.framework"
+               BlueprintName = "TripServiceKata"
+               ReferencedContainer = "container:TripServiceKata.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "TripServiceKata::TripServiceKataTests"
+               BuildableName = "TripServiceKataTests.xctest"
+               BlueprintName = "TripServiceKataTests"
+               ReferencedContainer = "container:TripServiceKata.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "TripServiceKata::TripServiceKata"
+            BuildableName = "TripServiceKata.framework"
+            BlueprintName = "TripServiceKata"
+            ReferencedContainer = "container:TripServiceKata.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Swift 4.x/TripServiceKata/TripServiceKata.xcodeproj/xcshareddata/xcschemes/xcschememanagement.plist
+++ b/Swift 4.x/TripServiceKata/TripServiceKata.xcodeproj/xcshareddata/xcschemes/xcschememanagement.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>SchemeUserState</key>
+  <dict>
+    <key>TripServiceKata-Package.xcscheme</key>
+    <dict></dict>
+  </dict>
+  <key>SuppressBuildableAutocreation</key>
+  <dict></dict>
+</dict>
+</plist>


### PR DESCRIPTION
Created a Swift 4.x package for the kata after attending the Crafting Code workshop at DevTernity.

Advantages:
- Latest Swift syntax.
- Run tests from the command line. Xcode is not required.
- Faster test execution, since the package doesn't need to start the iOS simulator.

Further details and requirements can be found in the [README.md](https://github.com/florieger/trip-service-kata/blob/swift-4/Swift%204.x/TripServiceKata/README.md).

I decided to create a new folder called `Swift 4.x`.  
The old `Swift 2.x` folder still exists.