### PR TITLE
DependentClassCalledDuringUnitTestException extends RuntimeException

### DIFF
--- a/php/src/TripServiceKata/Exception/DependentClassCalledDuringUnitTestException.php
+++ b/php/src/TripServiceKata/Exception/DependentClassCalledDuringUnitTestException.php
@@ -2,9 +2,9 @@
 
 namespace TripServiceKata\Exception;
 
-use Exception;
+use RuntimeException;
 
-class DependentClassCalledDuringUnitTestException extends Exception
+class DependentClassCalledDuringUnitTestException extends RuntimeException
 {
 
 }


### PR DESCRIPTION
... instead of Exception since we do not want to handle them. If the DependentClassCalledDuringUnitTestException is a normal Exception class some IDEs highlight the code and displays a warning that this exception should be handled. The TripServer e.g., however, should not know that we internally throw the DependentClassCalledDuringUnitTestException and so the developer should not be warned by the IDE.