### PR TITLE
make TripService::GetTripsByUser non-static (same as Java version)

### DIFF
--- a/c++/packages/TripServiceSupport.h
+++ b/c++/packages/TripServiceSupport.h
@@ -27,7 +27,7 @@ private:
 class TripService
 {
 public:
-    static std::list<Trip> GetTripsByUser( User *user );
+    std::list<Trip> GetTripsByUser( User *user );
   
 };
 


### PR DESCRIPTION
Making the function non-static allows adding functions to the `TripService` class that can be overridden (i.e. virtual) and used from within `GetTripsByUser()`. Solving the exercise without this is much more complicated.

Furthermore, the C++ version then also matches the Java version.