### PR TITLE
Remove unnecessary dependency on Spring framework

### DIFF
--- a/java/trip-service-kata/pom.xml
+++ b/java/trip-service-kata/pom.xml
@@ -12,7 +12,6 @@
         <hamcrest.version>1.3</hamcrest.version>
         <junit.version>5.3.1</junit.version>
         <mockito.version>2.23.0</mockito.version>
-        <spring.version>3.1.1.RELEASE</spring.version>
     </properties>
 
     <dependencies>
@@ -45,17 +44,6 @@
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-beans</artifactId>
-            <version>${spring.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-            <version>${spring.version}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
The Java implementation of the kata includes dependencies on the Spring framework. These dependencies don't seem to be used or to have any purpose. This PR removes them. 