### PR TITLE
Get mockito-kotlin from maven central

### DIFF
--- a/kotlin/trip-service-kata/pom.xml
+++ b/kotlin/trip-service-kata/pom.xml
@@ -15,7 +15,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.8</mockito.version>
-        <mockito-kotlin.version>0.5.0</mockito-kotlin.version>
+        <mockito-kotlin.version>2.2.11</mockito-kotlin.version>
     </properties>
 
     <dependencies>
@@ -42,7 +42,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.nhaarman</groupId>
+            <groupId>org.mockito.kotlin</groupId>
             <artifactId>mockito-kotlin</artifactId>
             <version>${mockito-kotlin.version}</version>
             <scope>test</scope>
@@ -55,14 +55,6 @@
         </dependency>
 
     </dependencies>
-
-    <repositories>
-        <!-- for mockito-kotlin -->
-        <repository>
-            <id>bintray-nhaarman-maven</id>
-            <url>http://dl.bintray.com/nhaarman/maven</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>


### PR DESCRIPTION
The Kotlin version of the kata uses the dependency "mockito-kotlin", for which it adds one extra repository: http://dl.bintray.com/nhaarman/maven

It looks like this was done before mockito-kotlin was available in maven central. Now it is available there so the extra repository is unnecessary.

(it may be more than unnecessary - the build doesn't work for me straight of the box as it looks like the repository may not even exist anymore. But I haven't investigated this).